### PR TITLE
Don't embed Swift Standard Libraries when building framework with project

### DIFF
--- a/RxBluetooth.xcodeproj/project.pbxproj
+++ b/RxBluetooth.xcodeproj/project.pbxproj
@@ -316,6 +316,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				EMBEDDED_CONTENT_CONTAINS_SWIFT = NO;
 				INFOPLIST_FILE = RxBluetooth/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -335,6 +336,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				EMBEDDED_CONTENT_CONTAINS_SWIFT = NO;
 				INFOPLIST_FILE = RxBluetooth/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";


### PR DESCRIPTION
Hi!

This fixes issue that causes iTunes Connect rejection when using Carthage.

> ERROR ITMS-90206: "Invalid Bundle. The bundle at 'My.app/Frameworks/RxBluetooth.framework' contains disallowed file 'Frameworks'."